### PR TITLE
A bug that may cause the image to be overexposed 

### DIFF
--- a/dehaze.py
+++ b/dehaze.py
@@ -16,7 +16,7 @@ def AtmLight(im,dark):
     darkvec = dark.reshape(imsz);
     imvec = im.reshape(imsz,3);
 
-    indices = darkvec.argsort();
+    indices = np.argsort(darkvec,axis=0);
     indices = indices[imsz-numpx::]
 
     atmsum = np.zeros([1,3])


### PR DESCRIPTION
A bug has been corrected, which will overexpose images with non-sky pixels in the upper left corner of the image after dehazing. The reason is that darkvec.argsort does not work correctly in the AtmLight function.